### PR TITLE
Use opendatahub-io/openshift-test-kit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test"]
 	path = test
-	url = https://github.com/radanalyticsio/openshift-test-kit
+	url = https://github.com/opendatahub-io/openshift-test-kit.git


### PR DESCRIPTION
Update the openshift-test-kit submodule to use the repo under opendatahub-io.  This will give us full control of our peak testframework until we can deprecate it for a better solution